### PR TITLE
Fix splash image deadlink

### DIFF
--- a/content/posts/2019-03-02-getting-started.md
+++ b/content/posts/2019-03-02-getting-started.md
@@ -6,7 +6,7 @@ date: 2019-03-01 14:43:24
 author: bleda
 tags:
     - getting-started
-cover: https://pbs.twimg.com/profile_banners/710394749207896064/1547818514
+cover: https://images.unsplash.com/photo-1521321205814-9d673c65c167?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2253&q=80
 ---
 
 **Bleda** is a minimal blog starter theme for Gridsome, inspired by the design of the [Attila](https://github.com/zutrinken/attila) Ghost theme, and styled with [Tailwind CSS](https://tailwindcss.com).


### PR DESCRIPTION
The splash image URL for the getting started page leads to a 404. I replaced it with something else I found on unsplash. Feel free to modify the splash image URL