### PR TITLE
Fix OpenGraph Metadata and RSS Feed Item URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 dist
 static/feed.xml
 
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ src/.temp
 node_modules
 dist
 static/feed.xml
-
 .DS_Store

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -65,7 +65,7 @@ module.exports = {
         feedItemOptions: node => ({
           title: node.title,
           description: node.description,
-          url: 'https://gridsome-starter-bleda.netlify.com/' + node.slug,
+          url: 'https://gridsome-starter-bleda.netlify.com/' + node.path,
           author: node.author,
           date: node.date,
         }),
@@ -118,8 +118,3 @@ module.exports = {
       })
   },
 }
-
-
-
-
-

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -65,7 +65,7 @@ module.exports = {
         feedItemOptions: node => ({
           title: node.title,
           description: node.description,
-          url: 'https://gridsome-starter-bleda.netlify.com/' + node.path,
+          url: 'https://gridsome-starter-bleda.netlify.com' + node.path,
           author: node.author,
           date: node.date,
         }),

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -45,21 +45,21 @@ export default {
         {
           key: 'description',
           name: 'description',
-          content: 'Introduction to the Bleda blog starter for Gridsome.'
+          content: this.ogDescription
         },
 
         { property: "og:type", content: 'article' },
         { property: "og:title", content:'About' },
-        { property: "og:description", content: 'Introduction to the Bleda blog starter for Gridsome.' },
+        { property: "og:description", content: this.ogDescription },
         { property: "og:url", content: `${this.config.siteUrl}/about/` },
-        { property: "og:image", content: '/images/bleda-card.png' },
+        { property: "og:image", content: this.ogImageUrl },
 
         { name: "twitter:card", content: "summary_large_image" },
         { name: "twitter:title", content: 'About' },
-        { name: "twitter:description", content: 'Introduction to the Bleda blog starter for Gridsome.' },
+        { name: "twitter:description", content: this.ogDescription },
         { name: "twitter:site", content: "@cossssmin" },
         { name: "twitter:creator", content: "@cossssmin" },
-        { name: "twitter:image", content: '/images/bleda-card.png' },
+        { name: "twitter:image", content: this.ogImageUrl },
       ],
     }
   },
@@ -67,6 +67,12 @@ export default {
     config () {
       return config
     },
+    ogDescription () {
+      return 'Introduction to the Bleda blog starter for Gridsome.'
+    },
+    ogImageUrl () {
+      return `${this.config.siteUrl}/images/bleda-card.png`
+    }
   },
 }
 </script>

--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -122,9 +122,9 @@ export default {
     },
     postUrl () {
       let siteUrl = this.config.siteUrl
-      let postSlug = this.$page.post.slug
+      let postPath = this.$page.post.path
 
-      return postSlug ? `${siteUrl}/${postSlug}/` : `${siteUrl}/${slugify(this.$page.post.title)}/`
+      return postPath ? `${siteUrl}${postPath}` : `${siteUrl}/${slugify(this.$page.post.title)}/`
     },
     ogImageUrl () {
       return this.$page.post.cover || `${this.config.siteUrl}/images/bleda-card.png`
@@ -137,6 +137,7 @@ export default {
 query Post ($path: String) {
   post (path: $path) {
     title
+    path
     slug
     datetime: date (format: "YYYY-MM-DD HH:mm:ss")
     content


### PR DESCRIPTION
This PR includes some fixes including:

* There are duplicated messages in `About.vue`
  * Refactored duplicated messages into computed properties
* `siteURL + slug` doesn't represent the complete URL
  * Changed `slug` to `path` to show the correct URL on:
    * OpenGraph metadata for the post URL in `Post.vue`
    * RSS feed item URL in `gridsome.config.js`

It would be great if you take a look and merge it.